### PR TITLE
Sorting issues

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -22,6 +22,9 @@ subtest "toposort" => sub {
     is_deeply([toposort({a=>["b"], b=>["c","d"], d=>["c"]},
                         [qw/b a/])],
               [qw/a b/]);
+    is_deeply([toposort({a=>["b"], b=>["c","d"], d=>["c"], e=>["b"]},
+                        [qw/a b c d e/])],
+              [qw/a e b d c/]);
     is_deeply([toposort({a=>["b"], b=>["c","d"], d=>["c"]},
                         [qw/e a b a/])],
               [qw/a a b e/]);


### PR DESCRIPTION
Hello,

   I'm starting to move from Sort::Topological in a project to Data::Graph::Util. When migrating the code to Data::Graph::Util, I've found that the order array passed in to toposort is not always honored.

   The first level (no dependants) array which is constructed (https://github.com/perlancar/perl-Data-Graph-Util/blob/master/lib/Data/Graph/Util.pm#L27) doesn't get sorted with the optional sort order parameter, making the ordering of the first elements unpredictable, where otherwise it should be
